### PR TITLE
[ENHANCEMENT] Remove `default` keyword

### DIFF
--- a/crates/lexer/src/tokens/keyword.rs
+++ b/crates/lexer/src/tokens/keyword.rs
@@ -52,8 +52,6 @@ pub enum Keyword {
     Const,
     /// The `continue` keyword. Used to continue a loop before all of it's code is executed.
     Continue,
-    /// The `default` keyword. Used in combination with the [`match`](`Keyword::Match`) and [`case`](`Keyword::Case`) keywords to match the default case.
-    Default,
     /// The `else` keyword. Used to define the "otherwise" block of an [`if`](`Keyword::If`) statement.
     Else,
     /// The `finally` keyword. Used in combination with the [`try`](`Keyword::Try`) keyword to execute code even after an exception has been raised.
@@ -66,7 +64,7 @@ pub enum Keyword {
     If,
     /// The `import` keyword. Used to import code from other modules.
     Import,
-    /// The `match` keyword. Used in combination with the [`case`](`Keyword::Case`) and [`default`](`Keyword::Default`) keywords.
+    /// The `match` keyword. Used in combination with the [`case`](`Keyword::Case`) keyword.
     Match,
     /// The `pub` keyword. Used to export an item out of the current scope.
     Pub,
@@ -96,7 +94,6 @@ impl core::fmt::Display for Keyword {
             &Self::Class => write!(formatter, "class"),
             &Self::Const => write!(formatter, "const"),
             &Self::Continue => write!(formatter, "continue"),
-            &Self::Default => write!(formatter, "default"),
             &Self::Else => write!(formatter, "else"),
             &Self::Finally => write!(formatter, "finally"),
             &Self::For => write!(formatter, "for"),
@@ -156,11 +153,6 @@ impl GetToken for Keyword {
                 location,
                 content: "continue".to_owned(),
                 token_type: TokenType::Keyword(Keyword::Continue),
-            }),
-            "default" => Some(Token {
-                location,
-                content: "default".to_owned(),
-                token_type: TokenType::Keyword(Keyword::Default),
             }),
             "else" => Some(Token {
                 location,

--- a/crates/lexer/tests/tokens/keyword.rs
+++ b/crates/lexer/tests/tokens/keyword.rs
@@ -48,7 +48,6 @@ mod tests {
         assert_eq!(&format!("{}", Keyword::Class), "class");
         assert_eq!(&format!("{}", Keyword::Const), "const");
         assert_eq!(&format!("{}", Keyword::Continue), "continue");
-        assert_eq!(&format!("{}", Keyword::Default), "default");
         assert_eq!(&format!("{}", Keyword::Else), "else");
         assert_eq!(&format!("{}", Keyword::Finally), "finally");
         assert_eq!(&format!("{}", Keyword::For), "for");
@@ -81,7 +80,6 @@ mod tests {
         assert!(generate_test(&location, "class", Keyword::Class));
         assert!(generate_test(&location, "const", Keyword::Const));
         assert!(generate_test(&location, "continue", Keyword::Continue));
-        assert!(generate_test(&location, "default", Keyword::Default));
         assert!(generate_test(&location, "else", Keyword::Else));
         assert!(generate_test(&location, "finally", Keyword::Finally));
         assert!(generate_test(&location, "for", Keyword::For));


### PR DESCRIPTION
# Description

Removed the `default` keyword from the lexer.

Closes #119

## Type of change

<!-- Select the relevant option(s) -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Language feature removal

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors or linter warnings
- [x] My changes generate no problems with other code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests passed locally with my changes
